### PR TITLE
fix serialize hardBreak node type undefined

### DIFF
--- a/src/serialize/state.js
+++ b/src/serialize/state.js
@@ -64,17 +64,6 @@ export class MarkdownSerializerState extends BaseMarkdownSerializerState {
      * update some nodes name due to serializer requiring on it
      */
     withSerializableSchema(schema, render) {
-        const { hardBreak } = schema.nodes;
-
-        if(hardBreak) {
-            hardBreak.name = 'hard_break';
-            this.nodes.hard_break = this.nodes.hardBreak;
-        }
-
         render();
-
-        if(hardBreak) {
-            hardBreak.name = 'hardBreak';
-        }
     }
 }


### PR DESCRIPTION
Crash after typing hard break in a table (non-standard Markdown table) cell.

![tiptap-markdown-1](https://user-images.githubusercontent.com/2498173/237059484-e1348ebd-dc73-4702-9868-190d9a40e568.gif)

![tiptap-markdown-2](https://user-images.githubusercontent.com/2498173/237060064-83c0683f-faf9-4963-99d4-b2352ad55c39.png)

![tiptap-markdown-3](https://user-images.githubusercontent.com/2498173/237060090-d76a5444-953b-4e00-b518-bbc9cadf64da.png)

### Fixed

![tiptap-markdown-fixed](https://user-images.githubusercontent.com/2498173/237060112-88df5550-32af-4e62-97c1-b640b140d58e.gif)

