### PR TITLE
Fix extension typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,4 +43,4 @@ export type MarkdownMarkSpec<O = any> = {
     },
 }
 
-export declare const Markdown = Extension<MarkdownOptions, MarkdownStorage>;
+export declare const Markdown: Extension<MarkdownOptions, MarkdownStorage>;


### PR DESCRIPTION
Typescript complains that it should be instantiated as a constructor e.g. `new Markdown` and when you try to do `Markdown.configure`. This change resolves that issue, I looked at how StarterKit is defined for reference: `export declare const StarterKit: Extension<StarterKitOptions, any>;`