### PR TITLE
firstElementChild can be null and should be taken into account

### DIFF
--- a/src/parse/MarkdownParser.js
+++ b/src/parse/MarkdownParser.js
@@ -78,7 +78,7 @@ export class MarkdownParser {
     }
 
     normalizeInline(node, content) {
-        if(node.firstElementChild.matches('p')) {
+        if(node.firstElementChild?.matches('p')) {
             const firstParagraph = node.firstElementChild;
             const { nextSibling, nextElementSibling } = firstParagraph;
             const startSpaces = content.match(/^\s+/)?.[0] ?? '';


### PR DESCRIPTION
firstElementChild can be null in a node and this should be taken into account.

An example is when
```
editor?.commands.insertContent('\n', {
	parseOptions: { preserveWhitespace: 'full' }
});
```

cc: @aguingand 