### PR TITLE
fix: add missing transform types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ export interface MarkdownOptions  {
     bulletListMarker?: String,
     linkify?: Boolean,
     breaks?: Boolean,
+    transformPastedText?: Boolean,
+    transformCopiedText?: Boolean,
 }
 
 export interface MarkdownStorage {


### PR DESCRIPTION
Love this repo! Amazing work :)

With the release of 0.8.0, 

```
  transformPastedText: false,  // Allow to paste markdown text in the editor
  transformCopiedText: false,  // Copied text is transformed to markdown
```
was added, however was not added to the types definition, this pr fixes that :) 