### PR TITLE
Fix missing `escape` field for marks extensions

### DIFF
--- a/src/serialize/MarkdownSerializer.js
+++ b/src/serialize/MarkdownSerializer.js
@@ -60,6 +60,7 @@ export class MarkdownSerializer {
         const serialize = getMarkdownSpec(mark)?.serialize;
         return serialize
             ? {
+                ...serialize,
                 open: typeof serialize.open === 'function' ? serialize.open.bind({ editor: this.editor, options: mark.options }) : serialize.open,
                 close: typeof serialize.close === 'function' ? serialize.close.bind({ editor: this.editor, options: mark.options }) : serialize.close,
             }


### PR DESCRIPTION
`prosemirror-markdown`  uses the field `escape` to check if the current mark needs to be escaped or not