### PR TITLE
Add types field to package exports for module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "import": "./dist/tiptap-markdown.es.js",
-      "require": "./dist/tiptap-markdown.umd.js"
+      "require": "./dist/tiptap-markdown.umd.js",
+      "types": "./index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Setting "moduleResolution": "bundler" in tsconfig.json results in the following TypeScript error for 'tiptap-markdown':

>path/to/TiptapEditor.tsx:YY:XX - error TS7016: Could not find a declaration file for module 'tiptap-markdown'. '/path/to/node_modules/tiptap-markdown/dist/tiptap-markdown.es.js' implicitly has an 'any' type.
>There are types at '/path/to/node_modules/tiptap-markdown/index.d.ts', but this result could not be resolved when respecting package.json "exports".

So I suggest adding a "types" field to the exports in package.json. This change will enable TypeScript to correctly find and use the type definitions for 'tiptap-markdown'.