### PR TITLE
fix: check for null value in normalizaDOM()

### DIFF
--- a/src/parse/MarkdownParser.js
+++ b/src/parse/MarkdownParser.js
@@ -47,7 +47,7 @@ export class MarkdownParser {
 
         // remove all \n appended by markdown-it
         node.querySelectorAll('*').forEach(el => {
-            if(el.nextSibling?.nodeType === Node.TEXT_NODE && !el.closest('pre')) {
+            if(el.nextSibling?.nodeType === Node.TEXT_NODE && !el.closest('pre') && el.nextSibling) {
                 el.nextSibling.textContent = el.nextSibling.textContent.replace(/^\n/, '');
             }
         });


### PR DESCRIPTION
`el.nextSibling` is nullable. so  add to check for null value.

```bash
851 |     } = _ref2;
852 |     this.normalizeBlocks(node);
853 |     node.querySelectorAll("*").forEach((el) => {
854 |       var _el$nextSibling;
855 |       if (((_el$nextSibling = el.nextSibling) === null || _el$nextSibling === void 0 ? void 0 : _el$nextSibling.nodeType) === Node.TEXT_NODE && !el.closest("pre")) {
856 |         el.nextSibling.textContent = el.nextSibling.textContent.replace(/^\n/, "");
                                              ^
TypeError: null is not an object (evaluating 'el.nextSibling.textContent')
```