### PR TITLE
Update hard-break.js

### DIFF
--- a/src/extensions/nodes/hard-break.js
+++ b/src/extensions/nodes/hard-break.js
@@ -18,7 +18,7 @@ export default HardBreak.extend({
                             state.write(
                                 state.inTable
                                     ? HTMLNode.storage.markdown.serialize.call(this, state, node, parent)
-                                    : "\\\n"
+                                    : "\n"
                             );
                             return;
                         }


### PR DESCRIPTION
The current setup with \\\n  creates an extra \ at the end of each line with a hardbreak.

remove the extra \ on the end of each line after serializing