### PR TITLE
chore: better warning highlight in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The markdown extension for [Tiptap editor](https://www.tiptap.dev/).
 
-> **Warning**  
+> [!WARNING]
 > Since v0.7.0, `createMarkdownEditor` has been dropped in favor of a more friendly `Markdown` Tiptap extension. See the [migration guide](https://github.com/aguingand/tiptap-markdown/blob/main/docs/migration.md).
 
 ## Installation


### PR DESCRIPTION
Updates the warning message format to use GitHub's newer `[!WARNING]` alert syntax instead of the older `**Warning**` format, aligning with GitHub's documentation standards.
(See [GitHub Alert Syntax Documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts))

This will help with better visibility for users who are just skimming the docs.

### Before
<img width="912" alt="image" src="https://github.com/user-attachments/assets/f907e0a3-d9d0-414a-85a9-e4a90071498b" />

### After
<img width="925" alt="image" src="https://github.com/user-attachments/assets/6654c5a9-ed96-4a0b-be2d-ffcde56e3751" />
